### PR TITLE
Fix non-responsive zoom by unifying zoom→distance mapping in camera state

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/ic_zoom_in.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_zoom_in.xml
@@ -1,0 +1,7 @@
+<!-- zoom in drawable -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="#ffffff" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+
+</vector>
+

--- a/composeApp/src/commonMain/composeResources/drawable/ic_zoom_out.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_zoom_out.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+
+    <path android:fillColor="#ffffff" android:pathData="M240,520L240,440L720,440L720,520L240,520Z"/>
+
+</vector>

--- a/krossmap/src/androidMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.android.kt
+++ b/krossmap/src/androidMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.android.kt
@@ -11,6 +11,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.rememberCameraPositionState
+import com.farimarwat.krossmap.model.KrossCoordinate
 
 actual class KrossCameraPositionState(
      internal val googleCameraPositionState: CameraPositionState?
@@ -18,6 +19,17 @@ actual class KrossCameraPositionState(
 
     actual var tilt by mutableStateOf(0f)
     actual var cameraFollow by mutableStateOf(true)
+
+    actual val center: KrossCoordinate?
+        get() {
+            val position = googleCameraPositionState?.position ?: return null
+            val target = position.target
+            return KrossCoordinate(
+                latitude = target.latitude,
+                longitude = target.longitude,
+                bearing = position.bearing
+            )
+        }
     actual suspend fun animateCamera(
         latitude: Double?,
         longitude: Double?,

--- a/krossmap/src/commonMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.kt
+++ b/krossmap/src/commonMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.kt
@@ -1,6 +1,7 @@
 package com.farimarwat.krossmap.core
 
 import androidx.compose.runtime.Composable
+import com.farimarwat.krossmap.model.KrossCoordinate
 
 /**
  * A multiplatform representation of a map camera controller and its state.
@@ -24,6 +25,12 @@ expect class KrossCameraPositionState {
      * When true, user interactions like dragging the map may reset camera position.
      */
     var cameraFollow: Boolean
+
+    /**
+     * Current center of the visible map region (camera target), if available.
+     * Returns null if the underlying map view/state is not yet ready.
+     */
+    val center: KrossCoordinate?
 
     /**
      * Animates the camera to the specified location and orientation.

--- a/krossmap/src/iosMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.ios.kt
+++ b/krossmap/src/iosMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.ios.kt
@@ -28,6 +28,19 @@ actual class KrossCameraPositionState(
     private var mapView: MKMapView? = null
     actual var cameraFollow by mutableStateOf(false)
 
+    actual val center: KrossCoordinate?
+        @OptIn(ExperimentalForeignApi::class)
+        get() {
+            val currentCamera = mapView?.camera ?: camera
+            val coord = currentCamera.centerCoordinate ?: return null
+            val (lat, lng) = coord.useContents { this.latitude to this.longitude }
+            return KrossCoordinate(
+                latitude = lat,
+                longitude = lng,
+                bearing = currentCamera.heading.toFloat()
+            )
+        }
+
     @OptIn(ExperimentalForeignApi::class)
     actual suspend fun animateCamera(
         latitude: Double?,

--- a/krossmap/src/iosMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.ios.kt
+++ b/krossmap/src/iosMain/kotlin/com/farimarwat/krossmap/core/KrossCameraPositionState.ios.kt
@@ -26,8 +26,6 @@ actual class KrossCameraPositionState(
 
     actual var tilt by mutableStateOf(0f)
     private var mapView: MKMapView? = null
-    private var baseDistance: Double = 10000.0
-
     actual var cameraFollow by mutableStateOf(false)
 
     @OptIn(ExperimentalForeignApi::class)
@@ -45,8 +43,7 @@ actual class KrossCameraPositionState(
 
         val coordinate = CLLocationCoordinate2DMake(latitude ?: lat, longitude ?: lng)
 
-        // Always calculate distance from base distance, not current distance
-        val distance = zoom?.let { zoomToDistanceFromBase(it) } ?: currentCamera.centerCoordinateDistance
+        val distance = zoom?.let { zoomToDistance(it) } ?: currentCamera.centerCoordinateDistance
 
         val newCamera = MKMapCamera.cameraLookingAtCenterCoordinate(
             centerCoordinate = coordinate,
@@ -58,18 +55,11 @@ actual class KrossCameraPositionState(
         mapView?.setCamera(newCamera, animated = true)
     }
 
-    private fun zoomToDistanceFromBase(zoom: Float): Double {
-        // Calculate distance based on base distance, not current distance
-        // Adjust this formula based on your zoom scale
-        return baseDistance / (2.0.pow(zoom.toDouble() - 10.0)) // Assuming zoom 10 = base distance
-    }
-
 
     @OptIn(ExperimentalForeignApi::class)
     internal fun setMapView(map: MKMapView) {
         mapView = map
         mapView?.setCamera(camera)
-        baseDistance = mapView?.camera?.centerCoordinateDistance ?: 15000.0
     }
 
 
@@ -103,6 +93,7 @@ actual fun rememberKrossCameraPositionState(
     }
     return state
 }
+
 fun zoomToDistance(zoom: Float): Double {
     val baseDistance =  when {
         zoom >= 20 -> 200.0       // was 170.0


### PR DESCRIPTION
**** Context:
On Android, cameraState.animateCamera(zoom = …) updates zoom correctly.
On iOS, zoom buttons appeared to do nothing.
**** Root cause:
Inconsistent conversion of zoom level to MapKit camera distance.
Initialization used a lookup-based zoomToDistance(zoom), while animateCamera used a different “base distance” formula; the mismatch produced negligible distance changes, so the zoom effect wasn’t visible.
**** Changes:
KrossCameraPositionState.ios.kt: use zoomToDistance(zoom) in animateCamera same mapping as initialization.
Remove the “base distance” logic and unused helper that caused an unresolved reference linter error.
Keep tilt/bearing behavior unchanged.
**** Impact:
Zoom buttons now work on iOS and match Android behavior.
Code is simpler and consistent; linter error resolved.




Adds `center` property to `KrossCameraPositionState`